### PR TITLE
use read-only url to clone git repo

### DIFF
--- a/contrib/libvirt/k8s-libvirt.sh
+++ b/contrib/libvirt/k8s-libvirt.sh
@@ -44,7 +44,7 @@ if [ "$1" == "apply" ]; then
     SALT_PATH="${SALT_PATH:-$PWD/../salt}"
     if ! [ -d "$SALT_PATH" ]; then
         echo "[+] Downloading kubic-project/salt to '$SALT_PATH'"
-        git clone git@github.com:kubic-project/salt "$SALT_PATH"
+        git clone https://github.com/kubic-project/salt "$SALT_PATH"
     else
         echo "[*] Already downloaded kubic-project/salt at '$SALT_PATH'"
     fi


### PR DESCRIPTION
otherwise access will be denied from machines that don't have
an ssh-key on github

the issue happened on the worker where we run the e2e-tests

Signed-off-by: Maximilian Meister <mmeister@suse.de>