### PR TITLE
Don't wait for MariaDB port 3306

### DIFF
--- a/provision/dashboard.sh
+++ b/provision/dashboard.sh
@@ -230,7 +230,6 @@ if [ -z "$FINISH" ] ; then
 
     # Wait for containers to be ready
     wait_for_container "k8s_velum-mariadb"         "mariadb database"
-    wait_for_port $MARIADB_PORT
     wait_for_container "k8s_salt-master"           "salt master"
     wait_for_port $SALT_MASTER_PORT
     wait_for_container "k8s_salt-minion-ca"        "certificate authority"


### PR DESCRIPTION
After https://github.com/kubic-project/velum/pull/104 MariaDB container doesn't expose port 3306