### PR TITLE
Variable for coping the manifests to the dashboard

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -25,12 +25,6 @@ as for some variables used in our templates.
 
 ### Main variables
 
-  * `salt_dir` _(optional)_
-
-    The directory where the Salt scripts are (`/usr/share/salt/kubernetes`
-    when installing the `kubernetes-salt` RPM, or a checkout of [this
-    repo](https://github.com/kubic-project/salt)).
-
   * `ssh_key` _(optional)_
 
     `ssh_key` is the key we will use for accessing machines (by default,
@@ -83,9 +77,27 @@ as for some variables used in our templates.
     specially helpful when you intend to download many Docker images and
     bandwidth is scarce.
 
+### Development variables
+
+Some variables are specially useful for developers (for example, for trying
+new stuff in local checkouts of repos)
+
+  * `salt_dir` _(optional)_
+
+    A directory with a _checkout_ of the [the Salt repo](https://github.com/kubic-project/salt).
+    It will be copied to `/usr/share/salt/kubernetes` in the VMs'
+    filesystems.
+
+  * `manifests_dir` _(optional)_
+
+    A directory with a _checkout_ of [the manifests repo](https://github.com/kubic-project/caasp-container-manifests).
+    It will be copied to `/usr/share/caasp-container-manifests` in the VMs'
+    filesystems.
+
   * `rw` _(optional)_
 
-    Make the whole filesystem read-writeable.
+    Make the whole filesystem read-writeable (enabled automatically
+    when `salt_dir` or `manifests_dir` have been provided)
 
 ### Controlling the Cluster created
 

--- a/terraform/inc/domain.inc
+++ b/terraform/inc/domain.inc
@@ -115,7 +115,7 @@ resource "<%= domain_type %>" "<%= name %>" {
 
     <% if enabled? "is_dashboard" %>
 
-        <% if enabled? "rw" or exists? "salt_dir" %>
+        <% if enabled? "rw" or exists? "salt_dir" or exists? "manifests_dir" %>
 
             # make the whole filesystem RW
             provisioner "remote-exec" {
@@ -133,6 +133,16 @@ resource "<%= domain_type %>" "<%= name %>" {
             provisioner "file" {
                 source      = "<%= salt_dir %>"
                 destination = "/usr/share/salt/kubernetes"
+            }
+
+        <% end %>
+
+        <% if exists? "manifests_dir" %>
+
+            # copy the manifests
+            provisioner "file" {
+                source      = "<%= manifests_dir %>"
+                destination = "/usr/share/caasp-container-manifests"
             }
 
         <% end %>


### PR DESCRIPTION
When testing new stuff, it is useful to use the manifests we have in a local checkout of the `caasp-container-manifests` repo. With this PR we can do that by defining `manifests_dir`