### PR TITLE
libvirt: add graph card back

### DIFF
--- a/terraform/inc/domain.inc
+++ b/terraform/inc/domain.inc
@@ -79,6 +79,11 @@ resource "<%= domain_type %>" "<%= name %>" {
             firmware = "<%= firmware %>"
         <% end %>
 
+        graphics {
+          type        = "vnc"
+          listen_type = "address"
+        }
+
     <% elsif provider == "openstack" %>
 
         <% if exists? "#{name}_flavor" %>


### PR DESCRIPTION
Add the graph card back, this is needed to interact with the machines using virt-manager's console.