### PR TITLE
Set fixed IPs on libvirt instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ osrc.sh
 .idea
 *.tfstate
 *.tfstate.backup
+*.tfstate.lock
+*.tfstate.lock.info
 *openrc*.sh
 .envrc
 

--- a/terraform/inc/net_iface.inc
+++ b/terraform/inc/net_iface.inc
@@ -14,6 +14,9 @@
         <% end %>
 
         hostname       = "<%= hostname %>"
+        <% if !exists?("net_cidr") %>
+            addresses      = ["10.17.3.${count.index}"]
+        <% end %>
         wait_for_lease = 1
     }
 

--- a/terraform/inc/network.inc
+++ b/terraform/inc/network.inc
@@ -70,7 +70,7 @@
         <% if exists?("net_cidr") %>
             addresses = ["<%= net_cidr %>"]
         <% else %>
-            addresses = ["10.17.3.0/24"]
+            addresses = ["10.17.2.0/23"]
         <% end %>
     }
 


### PR DESCRIPTION
I'm aware this is a hack, and wont work when a custom CIDR is used. However
it should help with CI reliability.