### PR TITLE
Add Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,5 @@
+def targetBranch = env.getEnvironment().get('CHANGE_TARGET', env.BRANCH_NAME)
+
+library "kubic-jenkins-library@${targetBranch}"
+
+coreKubicProjectCi()


### PR DESCRIPTION
The Jenkinsfile in each repo, if we adopt Jenkins in the end, will be very
thin, including just a single library load, and a single method call. This
prevents us from needing to keep each projects Jenkinsfile in sync as CI
changes are made.

As the terraform is not packaged, including it in just this repo allows for
dev/test of the CI without impacting the core codebase. Backing out
this change should we decide to go another route is also reasonable,
given we're only adding it here for now.